### PR TITLE
Fix 'Callback must be a function' error when running sassdoc

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -56,7 +56,12 @@ var buildDocs = function(template, ctx, dest) {
     fs.writeFile(
       filePath,
       swig.renderFile(template, ctx),
-      { flag: 'w' }
+      { flag: 'w' },
+      function(err) {
+        if (err) {
+          console.log("Error", err);
+        }
+      }
     );
   }
   return true;


### PR DESCRIPTION
Added a callback to the fs.writefile() call, as it was throwing an error on newer versions of Node when invoking sassdoc.
