### PR TITLE
Use writeFileSync instead of writeFile

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -53,7 +53,7 @@ var buildDocs = function(template, ctx, dest) {
     ensureDirectoryExistence(filePath);
 
     // Write file to destination.
-    fs.writeFile(
+    fs.writeFileSync(
       filePath,
       swig.renderFile(template, ctx),
       { flag: 'w' }


### PR DESCRIPTION
Currently using this theme crashes in node 10+ because node 10+ insists on having a callback function if you're doing  an async write.

I figured as you do everything else sync then doing this sync too is preferable to handling an error with a callback

This lets everything work on node 10+

Closes #1